### PR TITLE
[10.0] Fix bug in standard_plus_issue

### DIFF
--- a/standard_plus_issue/models/standard_plus_issue.py
+++ b/standard_plus_issue/models/standard_plus_issue.py
@@ -44,7 +44,6 @@ class StandardPlusIssue(models.Model):
     support_type_id = fields.Many2one(
         string='Support Type',
         comodel_name='issue.support.type',
-        required=True,
     )
 
     module_id = fields.Many2one(

--- a/standard_plus_issue/views/standard_plus_issue.xml
+++ b/standard_plus_issue/views/standard_plus_issue.xml
@@ -23,7 +23,7 @@
             <group name="main">
               <group>
                 <field name="type" attrs="{'readonly': [('state', 'in', ['submitted', 'addressed', 'rejected'])]}"/>
-                <field name="support_type_id" attrs="{'invisible': [('type', '!=', 'support')],'readonly': [('state', 'in', ['submitted', 'addressed', 'rejected'])]}"/>
+                <field name="support_type_id" attrs="{'invisible': [('type', '!=', 'support')],'readonly': [('state', 'in', ['submitted', 'addressed', 'rejected'])], 'required': [('type', '=', 'support')]}"/>
                 <field name="module_id" attrs="{'invisible': [('type', '!=', 'support')], 'readonly': [('state', 'in', ['submitted', 'addressed', 'rejected'])]}"/>
                 <field name="model_id" attrs="{'invisible': [('type', '=', 'support')], 'readonly': [('state', 'in', ['submitted', 'addressed', 'rejected'])]}"/>
               </group>


### PR DESCRIPTION
Before : the field support type doesn't appear for issues of type studio but still the issue can not be saved because this field is required.

After : the field support type is only required when the type of the issue is support.