### PR TITLE
[11.0]Fix retrieval date test

### DIFF
--- a/standard_plus_issue_studio/tests/test_standard_plus_issue.py
+++ b/standard_plus_issue_studio/tests/test_standard_plus_issue.py
@@ -31,11 +31,10 @@ class TestStandardPlusIssue(TransactionCase):
     def test_action_set_submitted(self):
         attachment_count = self.AttachmentObj.search_count([])
         self.assertEqual(self.issue.state, 'draft')
+        self.assertFalse(self.issue.studio_retrieval_date)
         self.issue.action_set_submitted()
         self.assertTrue(self.issue.studio_module)
-        self.assertEqual(
-            self.issue.studio_retrieval_date[:-2], fields.Datetime.now()[:-2]
-        )
+        self.assertTrue(self.issue.studio_retrieval_date)
         self.assertEqual(self.issue.state, 'submitted')
         self.assertEqual(
             attachment_count, self.AttachmentObj.search_count([])


### PR DESCRIPTION
Test Error: standard_plus_issue_studio.tests.test_standard_plus_issue

ERROR Synergie-Tests odoo.addons.standard_plus_issue_studio.tests.test_standard_plus_issue: ` self.issue.studio_retrieval_date[:-2], fields.Datetime.now()[:-2]
ERROR Synergie-Tests odoo.addons.standard_plus_issue_studio.tests.test_standard_plus_issue: ` AssertionError: '2018-04-06 21:18:' != '2018-04-06 21:19:'